### PR TITLE
Add Grafana on port 3001

### DIFF
--- a/config/grafana/grafana.ini
+++ b/config/grafana/grafana.ini
@@ -1,0 +1,18 @@
+[server]
+http_port = 3001
+protocol = http
+domain = localhost
+
+[security]
+allow_embedding = true
+cookie_secure = false
+
+[auth.anonymous]
+enabled = true
+org_role = Admin
+
+[dashboards]
+default_home_dashboard_path = /etc/grafana/dashboards/home.json
+
+[paths]
+provisioning = /etc/grafana/provisioning

--- a/docker-compose.fast.yml
+++ b/docker-compose.fast.yml
@@ -120,10 +120,34 @@ services:
       healthcare:
         condition: service_healthy
 
+  grafana:
+    image: grafana/grafana:latest
+    volumes:
+      - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3001:3001"
+    environment:
+      - GF_SERVER_HTTP_PORT=3001
+      - GF_SECURITY_ALLOW_EMBEDDING=true
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3001/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    depends_on:
+      healthcare:
+        condition: service_healthy
+
 volumes:
   pip-cache:
   node-modules:
   npm-cache:
+  grafana-data:
 
 networks:
   default:


### PR DESCRIPTION
This PR adds Grafana configuration and changes its port to avoid conflicts:

### Changes

1. Port Configuration:
   - Change Grafana port from 3000 to 3001
   - Keep other services unchanged:
     * Model Registry: 8000
     * Compliance: 8001
     * Healthcare: 8002
     * Frontend: 8003

2. Grafana Configuration:
   - Add grafana.ini configuration file
   - Enable anonymous access for development
   - Configure dashboard provisioning
   - Install useful plugins:
     * grafana-clock-panel
     * grafana-simple-json-datasource

3. Docker Configuration:
   - Add persistent volume for Grafana data
   - Add health check for Grafana service
   - Configure service dependencies
   - Add proper startup order

### Testing
```bash
# Clean up everything first
docker-compose -f docker-compose.fast.yml down
docker volume prune -f

# Start services
docker-compose -f docker-compose.fast.yml up --build
```

### Access Points
- Grafana: http://localhost:3001
- Frontend UI: http://localhost:8003
- Healthcare API: http://localhost:8002
- Model Registry: http://localhost:8000
- Compliance: http://localhost:8001