### PR TITLE
Fix healthcare health check and port configuration

### DIFF
--- a/core/healthcare/api/main.py
+++ b/core/healthcare/api/main.py
@@ -36,10 +36,28 @@ async def log_prediction(prediction: PredictionLog):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/api/v1/health")
+@app.get("/health")
 async def health_check():
-    return {"status": "healthy"}
+    """Health check endpoint for Docker"""
+    try:
+        # Basic service checks
+        return {
+            "status": "healthy",
+            "service": "healthcare",
+            "timestamp": datetime.now().isoformat(),
+            "version": "1.0.0",
+            "port": int(os.getenv("PORT", 8002))
+        }
+    except Exception as e:
+        return {
+            "status": "unhealthy",
+            "error": str(e),
+            "service": "healthcare",
+            "timestamp": datetime.now().isoformat()
+        }, 500
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=50711)
+    port = int(os.getenv("PORT", 8002))
+    host = os.getenv("HOST", "0.0.0.0")
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
This PR fixes the healthcare service health check and port configuration:

### Changes

1. Health Check:
   - Move health check endpoint from `/api/v1/health` to `/health`
   - Add service information to health check response
   - Add better error handling
   - Add timestamps and version info

2. Port Configuration:
   - Fix port to use environment variable (8002)
   - Add host configuration from environment
   - Ensure consistent port usage

### Testing
```bash
# Clean up everything first
docker-compose -f docker-compose.fast.yml down
docker volume prune -f

# Start services
docker-compose -f docker-compose.fast.yml up --build

# Test health check
curl http://localhost:8002/health
```

### Access Points
- Frontend UI: http://localhost:8003
- Healthcare API: http://localhost:8002
- Model Registry: http://localhost:8000
- Compliance: http://localhost:8001
- Grafana: http://localhost:3001