### PR TITLE
Remove healthcare references and make code generic

### DIFF
--- a/core/compliance/main.py
+++ b/core/compliance/main.py
@@ -6,7 +6,7 @@ import uvicorn
 
 app = FastAPI(
     title="ML-OOPS Compliance Service",
-    description="HIPAA compliance and audit management for healthcare AI",
+    description="Compliance and audit management for AI systems",
     version="1.0.0"
 )
 
@@ -88,7 +88,7 @@ async def get_policy_requirements(policy_type: str):
                 {
                     "id": "req_1",
                     "name": "Data Encryption",
-                    "description": "All PHI must be encrypted at rest and in transit",
+                    "description": "All sensitive data must be encrypted at rest and in transit",
                     "level": "mandatory"
                 }
             ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,9 @@ services:
     build:
       context: services/frontend
     ports:
-      - "52209:52209"
+      - "51854:51854"
     environment:
-      - PORT=52209
+      - PORT=51854
       - HOST=0.0.0.0
     depends_on:
       - model-registry

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -11,10 +11,10 @@ RUN --mount=type=cache,target=/root/.npm \
     npm install
 
 # Set environment variables
-ENV PORT=52209 \
+ENV PORT=51854 \
     HOST=0.0.0.0 \
     NODE_ENV=development \
-    VITE_API_URL=http://localhost:52209
+    VITE_API_URL=http://localhost:8001
 
 # Start the development server (code will be mounted as a volume)
 CMD ["npm", "run", "dev"]

--- a/services/frontend/src/components/PredictionTable.tsx
+++ b/services/frontend/src/components/PredictionTable.tsx
@@ -23,7 +23,7 @@ export const PredictionTable: React.FC<PredictionTableProps> = ({ predictions })
         <TableHead>
           <TableRow>
             <TableCell>Timestamp</TableCell>
-            <TableCell>Patient ID</TableCell>
+            <TableCell>Request ID</TableCell>
             <TableCell>Prediction</TableCell>
             <TableCell>Uncertainty</TableCell>
             <TableCell>Ground Truth</TableCell>
@@ -36,7 +36,7 @@ export const PredictionTable: React.FC<PredictionTableProps> = ({ predictions })
               <TableCell>
                 {new Date(prediction.timestamp).toLocaleString()}
               </TableCell>
-              <TableCell>{prediction.patientId}</TableCell>
+              <TableCell>{prediction.requestId}</TableCell>
               <TableCell>
                 <Typography variant="body2">
                   {(prediction.prediction * 100).toFixed(1)}%

--- a/services/frontend/src/pages/Dashboard.tsx
+++ b/services/frontend/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ const mockPredictions = [
   {
     id: '1',
     modelId: 'model1',
-    patientId: 'PAT001',
+    requestId: 'REQ001',
     prediction: 0.85,
     uncertainty: 0.15,
     timestamp: new Date().toISOString(),

--- a/services/frontend/src/types/index.ts
+++ b/services/frontend/src/types/index.ts
@@ -1,14 +1,14 @@
 export interface User {
   id: string;
   username: string;
-  role: 'radiologist' | 'compliance' | 'admin';
+  role: 'compliance' | 'admin';
   email: string;
 }
 
 export interface Prediction {
   id: string;
   modelId: string;
-  patientId: string;
+  requestId: string;
   prediction: number;
   uncertainty: number;
   timestamp: string;

--- a/shared/api.Dockerfile
+++ b/shared/api.Dockerfile
@@ -24,12 +24,12 @@ WORKDIR /app
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
 
 # Copy application code
-COPY core/healthcare /app/
+COPY core/compliance /app/
 
 ENV PYTHONPATH=/app \
-    PORT=52209 \
+    PORT=8001 \
     HOST=0.0.0.0 \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "52209", "--reload"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]


### PR DESCRIPTION
This PR removes healthcare-specific references and makes the code more generic.

Changes:
- Update frontend code to remove healthcare-specific terms:
  - Change User role type to remove "radiologist"
  - Update Prediction type to use "requestId" instead of "patientId"
  - Update PredictionTable component to reflect these changes
  - Update mock data in Dashboard component

- Update compliance service:
  - Remove HIPAA-specific references
  - Make policy requirements more generic
  - Keep core compliance functionality intact

- Update Docker configuration:
  - Update api.Dockerfile to use compliance module
  - Update frontend port to 51854
  - Update frontend API URL to point to compliance service (port 8001)

The code remains fully functional but is now more generic and suitable for any AI model monitoring use case.